### PR TITLE
add pavement script to help with dev, refs #71

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,8 @@
 /src/build.xml
 /doc/build
 *.pyc
-ext_libs
 test-output/
+ext-libs
+ext-src
+build
+opengeo.zip

--- a/pavement.py
+++ b/pavement.py
@@ -1,0 +1,169 @@
+from cStringIO import StringIO
+import ConfigParser
+from datetime import date
+import fnmatch
+import os
+from paver.easy import *
+# this pulls in the sphinx target
+from paver.doctools import html
+import xmlrpclib
+import zipfile
+
+
+options(
+    plugin = Bunch(
+        name = 'opengeo',
+        ext_libs = path('src/opengeo/ext-libs'),
+        ext_src = path('src/opengeo/ext-src'),
+        source_dir = path('src/opengeo'),
+        package_dir = path('.'),
+        excludes = [
+            'metadata.txt',
+            'test-output',
+            '*.pyc'
+        ]
+    ),
+
+    plugin_server = Bunch(
+        server = 'plugins.qgis.org',
+        port = 80,
+        protocol = 'http',
+        end_point = '/plugins/RPC2/'
+    ),
+
+    sphinx = Bunch(
+        docroot = 'doc',
+        sourcedir = 'source',
+        builddir = 'build'
+    )
+)
+
+
+
+@task
+@cmdopts([
+    ('clean', 'c', 'clean out dependencies first'),
+])
+def setup(options):
+    '''install dependencies'''
+    clean = getattr(options, 'clean', False)
+    ext_libs = options.plugin.ext_libs
+    ext_src = options.plugin.ext_src
+    if clean:
+        ext_libs.rmtree()
+    ext_libs.makedirs()
+    runtime, test = read_requirements()
+    for req in runtime + test:
+        if req.startswith('-e'):
+            # use pip to just process the URL and fetch it in to place
+            sh('pip install --no-install --src=%s %s' % (ext_src, req))
+            # now change the req to be the location installed to
+            # and easy_install will do the rest
+            urlspec, req = req.split('#egg=')
+        sh('PYTHONPATH=%(ext_libs)s easy_install -a -d %(ext_libs)s %(dep)s' % {
+            'ext_libs' : ext_libs,
+            'dep' : req
+        })
+
+
+def read_requirements():
+    '''return a list of runtime and list of test requirements'''
+    lines = open('requirements.txt').readlines()
+    lines = [ l for l in [ l.strip() for l in lines] if l ]
+    divider = '# test requirements'
+    try:
+        idx = lines.index(divider)
+    except ValueError:
+        raise BuildFailure('expected to find "%s" in requirements.txt' % divider)
+    not_comments = lambda s,e: [ l for l in lines[s:e] if l[0] != '#']
+    return not_comments(0, idx), not_comments(idx+1, None)
+
+
+@task
+def install(options):
+    '''install plugin to qgis'''
+    plugin_name = options.plugin.name
+    src = path(__file__).dirname() / plugin_name
+    dst = path('~').expanduser() / '.qgis2' / 'python' / 'plugins' / plugin_name
+    src = src.abspath()
+    dst = dst.abspath()
+    if not hasattr(os, 'symlink'):
+        dst.rmtree()
+        src.copytree(dst)
+    elif not dst.exists():
+        src.symlink(dst)
+
+
+@task
+def package(options):
+    '''create package for plugin'''
+    package_file = options.plugin.package_dir / ('%s.zip' % options.plugin.name)
+    with zipfile.ZipFile(package_file, "w", zipfile.ZIP_DEFLATED) as zip:
+        make_zip(zip, options)
+    return package_file
+
+
+def make_zip(zip, options):
+    metadata_file = options.plugin.source_dir / "metadata.txt"
+    cfg = ConfigParser.SafeConfigParser()
+    cfg.optionxform = str
+    cfg.read(metadata_file)
+    base_version = cfg.get('general', 'version')
+    cfg.set("general", "version", "%s-%s" % (base_version, date.today().strftime("%Y%m%d")))
+
+    buf = StringIO()
+    cfg.write(buf)
+    zip.writestr("opengeo/metadata.txt", buf.getvalue())
+
+    excludes = set(options.plugin.excludes)
+
+    src_dir = options.plugin.source_dir
+    exclude = lambda p: any([fnmatch.fnmatch(p, e) for e in excludes])
+    def filter_excludes(files):
+        if not files: return []
+        # to prevent descending into dirs, modify the list in place
+        for f in files:
+            if exclude(f):
+                debug('excluding %s' % f)
+                files.remove(f)
+        return files
+
+    for root, dirs, files in os.walk(src_dir):
+        for f in filter_excludes(files):
+            relpath = os.path.relpath(root, 'src')
+            zip.write(path(root) / f, path(relpath) / f)
+        filter_excludes(dirs)
+
+
+@task
+@cmdopts([
+    ('user=', 'u', 'upload user'),
+    ('passwd=', 'p', 'upload password'),
+])
+def upload(options):
+    '''upload the package to the server'''
+    package_file = package(options)
+    user, passwd = getattr(options, 'user', None), getattr(options, 'passwd', None)
+    if not user or not passwd:
+        raise BuildFailure('provide user and passwd options to upload task')
+    # create URL for XML-RPC calls
+    s = options.plugin_server
+    uri = "%s://%s:%s@%s:%s%s" % (s.protocol, options['user'], options['passwd'], s.server, s.port, s.end_point)
+    info('uploading to %s', uri)
+    server = xmlrpclib.ServerProxy(uri, verbose=False)
+    try:
+        pluginId, versionId = server.plugin.upload(xmlrpclib.Binary(package_file.bytes()))
+        info("Plugin ID: %s", pluginId)
+        info("Version ID: %s", versionId)
+        package_file.unlink()
+    except xmlrpclib.Fault, err:
+        error("A fault occurred")
+        error("Fault code: %d", err.faultCode)
+        error("Fault string: %s", err.faultString)
+    except xmlrpclib.ProtocolError, err:
+        error("Protocol error")
+        error("%s : %s", err.errcode, err.errmsg)
+        if err.errcode == 403:
+            error("Invalid name and password?")
+
+    

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+httplib2==0.8
+requests==2.0.1
+raven==3.5.1
+# when ready, uncomment this to pull in from source
+#-e git+https://github.com/opengeo/gsconfig.git#egg=gsconfig
+
+# test requirements
+nose==1.3.0
+nose-html==1.1
+coverage==3.7
+

--- a/src/opengeo/__init__.py
+++ b/src/opengeo/__init__.py
@@ -3,8 +3,8 @@
 import sys
 import os
 import site
-#sys.path.append(os.path.abspath(os.path.dirname(__file__) + '/ext_libs'))
-site.addsitedir(os.path.abspath(os.path.dirname(__file__) + '/ext_libs'))
+
+site.addsitedir(os.path.abspath(os.path.dirname(__file__) + '/ext-libs'))
 
 from opengeo.qgis.catalog import *
 


### PR DESCRIPTION
requires pavement, run paver help to get commands.

note - changes external libraries directory to ext-libs to prevent python path confusion (since ext-libs is not a valid package directory)

also supports adding 'source' requirements - git checkouts, like for gsconfig

replaces the install.py and package.py scripts, too

currently all tests and deps are packaged though this could be adjusted
