### PR TITLE
Documentation Fixes

### DIFF
--- a/doc/source/developers.rst
+++ b/doc/source/developers.rst
@@ -18,6 +18,7 @@ These are the libraries that the OpenGeo Explorer requires.
 - httplib2 (http://code.google.com/p/httplib2/)
 - raven (http://github.com/getsentry/raven-python)
 - requests (http://www.python-requests.org/en/latest/)
+- psycopg2 (http://initd.org/psycopg/docs/install.html)
 
 If you want to run the tests, you will also need:
 

--- a/doc/source/intro.rst
+++ b/doc/source/intro.rst
@@ -6,7 +6,7 @@ This section will give a basic introduction to the functionality of the OpenGeo 
 Installing the current development version
 ------------------------------------------
 
-The plugin repository is updated frequently. However, it is not guaranteed that it will contain the same code that can be found in the GitHub repository. If you want to be sure that you are using the latest development version, follow the steps described in the :ref:`developers` section.
+The plugin repository is updated frequently. However, it is not guaranteed that it will contain the same code that can be found in the GitHub repository. If you want to be sure that you are using the latest development version, follow the steps described in the :ref:`developers <developers>` section.
 
 Installing from a zip file
 --------------------------


### PR DESCRIPTION
While building the plugin locally, I ran into a couple of issues with our documentation.
 - The link to the developer docs was broken
 - When attempting to install the plugin locally, QGIS failed to load it due to the missing dependancy psycopg2. I have added this to the list of dependancies; I am not sure if this issue is OS specific or just out of date docs (I am developing on OS X)
