### PR TITLE
XML GeoServer component name fixes

### DIFF
--- a/src/opengeo/gui/contextualhelp.py
+++ b/src/opengeo/gui/contextualhelp.py
@@ -1,0 +1,34 @@
+"""
+Contextual help components for use in dialogs, etc.
+"""
+
+import os
+from PyQt4 import QtGui, QtCore
+
+
+# noinspection PyAttributeOutsideInit, PyPep8Naming
+class InfoIcon(QtGui.QLabel):
+    def __init__(self, tip, parent=None):
+        QtGui.QLabel.__init__(self, parent)
+        self.tiptxt = tip
+        self.setSizePolicy(QtGui.QSizePolicy.Fixed,
+                           QtGui.QSizePolicy.Fixed)
+        self.setMaximumSize(QtCore.QSize(16, 16))
+        self.setMinimumSize(QtCore.QSize(16, 16))
+        infopx = QtGui.QPixmap(
+            os.path.dirname(os.path.dirname(__file__)) + "/images/help.png")
+        self.setPixmap(infopx)
+
+        self.setMouseTracking(True)
+
+    def mouseMoveEvent(self, event):
+        # QtGui.QToolTip.showText(self.mapToGlobal(event.pos()),
+        #                         self.tiptxt, self, self.rect())
+        QtGui.QToolTip.showText(self.mapToGlobal(event.pos()),
+                                self.tiptxt, self)
+        event.ignore()
+
+
+# noinspection PyPep8Naming
+def infoIcon(tip, parent=None):
+    return InfoIcon(tip, parent)

--- a/src/opengeo/gui/dialogs/gsnamedialog.py
+++ b/src/opengeo/gui/dialogs/gsnamedialog.py
@@ -1,0 +1,115 @@
+"""
+Dialog to create a user-defined name for a GeoServer component, with optional
+validation.
+"""
+
+from PyQt4 import QtGui, QtCore
+
+APP = None
+if __name__ == '__main__':
+    import sys
+    # instantiate QApplication before importing QtGui subclasses
+    APP = QtGui.QApplication(sys.argv)
+
+from opengeo.gui.gsnameutils import GSNameWidget
+
+
+# noinspection PyAttributeOutsideInit, PyPep8Naming
+class GSNameDialog(QtGui.QDialog):
+
+    def __init__(self, boxtitle='', boxmsg='', name='', namemsg='',
+                 nameregex='', nameregexmsg='', names=None,
+                 unique=False, maxlength=0, parent=None):
+        super(GSNameDialog, self).__init__(parent)
+        self.boxtitle = boxtitle
+        self.boxmsg = boxmsg
+        self.nameBox = GSNameWidget(
+            name=name,
+            namemsg=namemsg,
+            nameregex=nameregex,
+            nameregexmsg=nameregexmsg,
+            names=names,
+            unique=unique,
+            maxlength=maxlength
+        )
+        self.initGui()
+
+    def initGui(self):
+        self.setWindowTitle('Define name')
+        vertlayout = QtGui.QVBoxLayout()
+
+        self.groupBox = QtGui.QGroupBox()
+        self.groupBox.setTitle(self.boxtitle)
+        self.groupBox.setLayout(vertlayout)
+
+        if self.boxmsg:
+            self.groupBoxMsg = QtGui.QLabel(self.boxmsg)
+            self.groupBoxMsg.setWordWrap(True)
+            self.groupBox.layout().addWidget(self.groupBoxMsg)
+
+        self.groupBox.layout().addWidget(self.nameBox)
+
+        layout = QtGui.QVBoxLayout()
+        layout.addWidget(self.groupBox)
+        self.buttonBox = QtGui.QDialogButtonBox(
+            QtGui.QDialogButtonBox.Ok | QtGui.QDialogButtonBox.Cancel)
+        self.okButton = self.buttonBox.button(QtGui.QDialogButtonBox.Ok)
+        self.cancelButton = self.buttonBox.button(QtGui.QDialogButtonBox.Cancel)
+        layout.addWidget(self.buttonBox)
+
+        self.setLayout(layout)
+
+        self.nameBox.nameValidityChanged.connect(self.okButton.setEnabled)
+        self.nameBox.overwritingChanged.connect(self.updateButtons)
+
+        # noinspection PyUnresolvedReferences
+        self.buttonBox.accepted.connect(self.accept)
+        # noinspection PyUnresolvedReferences
+        self.buttonBox.rejected.connect(self.reject)
+
+        self.setMinimumWidth(240)
+
+        # respond to intial validation
+        self.okButton.setEnabled(self.nameBox.isValid())
+        self.updateButtons(self.nameBox.overwritingName())
+
+    def definedName(self):
+        return self.nameBox.definedName()
+
+    def overwritingName(self):
+        return self.nameBox.overwritingName()
+
+    @QtCore.pyqtSlot(bool)
+    def updateButtons(self, overwriting):
+        txt = "Overwrite" if overwriting else "OK"
+        self.okButton.setText(txt)
+        self.okButton.setDefault(not overwriting)
+        self.cancelButton.setDefault(overwriting)
+
+
+if __name__ == '__main__':
+    from opengeo.gui.gsnameutils import \
+        xmlNameFixUp, xmlNameRegex, xmlNameRegexMsg
+    gdlg = GSNameDialog(
+        boxtitle='GeoServer data store name',
+        boxmsg='My groupbox message',
+        namemsg='Sample is generated from PostgreSQL connection name.',
+        # name=xmlNameFixUp('My PG connection'),
+        name='name_one',
+        nameregex=xmlNameRegex(),
+        nameregexmsg=xmlNameRegexMsg(),
+        names=['name_one', 'name_two'],
+        unique=False,
+        maxlength=10)
+    gdlg.exec_()
+    print gdlg.definedName()
+    print gdlg.overwritingName()
+    # and with no kwargs
+    gdlg = GSNameDialog()
+    gdlg.exec_()
+    print gdlg.definedName()
+    print gdlg.overwritingName()
+    # gdlg.show()
+    # gdlg.raise_()
+    # gdlg.activateWindow()
+    # sys.exit(APP.exec_())

--- a/src/opengeo/gui/dialogs/styledialog.py
+++ b/src/opengeo/gui/dialogs/styledialog.py
@@ -96,10 +96,14 @@ class StyleFromLayerDialog(QtGui.QDialog):
         
 class AddStyleToLayerDialog(QtGui.QDialog):
     
-    def __init__(self, catalog, parent = None):
+    def __init__(self, catalog, layer, parent = None):
         super(AddStyleToLayerDialog, self).__init__(parent)
         self.catalog = catalog
-        self.style = None            
+        self.layer = layer
+        styles = layer.styles
+        self.layerstyles = [style.name for style in styles]
+        self.layerdefaultstyle = layer.default_style.name
+        self.style = None
         self.default = None
         self.initGui()        
         
@@ -109,19 +113,31 @@ class AddStyleToLayerDialog(QtGui.QDialog):
         self.setWindowTitle('Add style to layer')
         
         horizontalLayout = QtGui.QHBoxLayout()
-        horizontalLayout.setSpacing(30)
-        horizontalLayout.setMargin(0)        
+        horizontalLayout.setMargin(0)
         styleLabel = QtGui.QLabel('Style')
+        styleLabel.setSizePolicy(
+            QtGui.QSizePolicy(QtGui.QSizePolicy.Maximum,
+                              QtGui.QSizePolicy.Fixed))
         self.styleBox = QtGui.QComboBox()
         styles = [style.name for style in self.catalog.get_styles()]
-        self.styleBox.addItems(styles)
+        sm = QtGui.QStandardItemModel()
+        defaultset = False
+        for style in styles:
+            isdefault = style == self.layerdefaultstyle
+            si = QtGui.QStandardItem(style)
+            si.setEnabled(style not in self.layerstyles and not isdefault)
+            if not defaultset and isdefault:
+                si.setText("{0} [default style]".format(style))
+                defaultset = True
+            sm.appendRow(si)
+        sm.sort(0)
+        self.styleBox.setModel(sm)
         horizontalLayout.addWidget(styleLabel)
         horizontalLayout.addWidget(self.styleBox)
         layout.addLayout(horizontalLayout)
         
         horizontalLayout = QtGui.QHBoxLayout()
-        horizontalLayout.setSpacing(30)
-        horizontalLayout.setMargin(0)                
+        horizontalLayout.setMargin(0)
         self.checkBox = QtGui.QCheckBox("Add as default style")        
         horizontalLayout.addWidget(self.checkBox)        
         layout.addLayout(horizontalLayout)

--- a/src/opengeo/gui/dialogs/styledialog.py
+++ b/src/opengeo/gui/dialogs/styledialog.py
@@ -43,7 +43,7 @@ class StyleFromLayerDialog(QtGui.QDialog):
                               QtGui.QSizePolicy.Fixed))
         defaultname = ''
         if len(self.alllayers) > 0:
-            defaultname = self.alllayers[0]
+            defaultname = xmlNameFixUp(self.alllayers[0])
         self.nameBox = GSNameWidget(
             namemsg='',
             name=defaultname,
@@ -69,13 +69,17 @@ class StyleFromLayerDialog(QtGui.QDialog):
         buttonBox.accepted.connect(self.okPressed)
         buttonBox.rejected.connect(self.cancelPressed)
 
-        self.layerBox.currentIndexChanged[str].connect(self.nameBox.setName)
+        self.layerBox.currentIndexChanged[str].connect(self.updateNameBox)
         self.nameBox.nameValidityChanged.connect(self.okButton.setEnabled)
         self.nameBox.overwritingChanged.connect(self.updateButtons)
         self.okButton.setEnabled(self.nameBox.isValid())
         self.updateButtons(self.nameBox.overwritingName())
         
         self.resize(400,150)
+
+    @QtCore.pyqtSlot(str)
+    def updateNameBox(self, name):
+        self.nameBox.setName(xmlNameFixUp(name))
 
     @QtCore.pyqtSlot(bool)
     def updateButtons(self, overwriting):

--- a/src/opengeo/gui/dialogs/workspacedialog.py
+++ b/src/opengeo/gui/dialogs/workspacedialog.py
@@ -1,9 +1,19 @@
 from PyQt4 import QtGui, QtCore
 
+APP = None
+if __name__ == '__main__':
+    import sys
+    # instantiate QApplication before importing QtGui subclasses
+    APP = QtGui.QApplication(sys.argv)
+
+from opengeo.gui.gsnameutils import GSNameWidget, xmlNameRegexMsg, xmlNameRegex
+
+
 class DefineWorkspaceDialog(QtGui.QDialog):
     
-    def __init__(self, parent = None):
+    def __init__(self, workspaces=None, parent=None):
         super(DefineWorkspaceDialog, self).__init__(parent)
+        self.workspaces = workspaces if workspaces is not None else []
         self.uri = None        
         self.name = None
         self.initGui()
@@ -18,9 +28,15 @@ class DefineWorkspaceDialog(QtGui.QDialog):
         horizontalLayout.setMargin(0)        
         nameLabel = QtGui.QLabel('Workspace name')
         nameLabel.setMinimumWidth(150)
-        self.nameBox = QtGui.QLineEdit()
-        self.nameBox.setText('workspace_name')
-        self.nameBox.setMinimumWidth(250)        
+        self.nameBox = GSNameWidget(
+            namemsg='',
+            name='workspace',
+            nameregex=xmlNameRegex(),
+            nameregexmsg=xmlNameRegexMsg(),
+            names=self.workspaces,
+            unique=True,
+            maxlength=10)
+        self.nameBox.setMinimumWidth(250)
         horizontalLayout.addWidget(nameLabel)
         horizontalLayout.addWidget(self.nameBox)
         verticalLayout.addLayout(horizontalLayout)
@@ -32,6 +48,7 @@ class DefineWorkspaceDialog(QtGui.QDialog):
         uriLabel.setMinimumWidth(150)
         self.uriBox = QtGui.QLineEdit()
         self.uriBox.setText('')
+        self.uriBox.setPlaceholderText('Required')
         self.uriBox.setMinimumWidth(250)
         horizontalLayout.addWidget(uriLabel)
         horizontalLayout.addWidget(self.uriBox)
@@ -45,23 +62,35 @@ class DefineWorkspaceDialog(QtGui.QDialog):
         self.spacer = QtGui.QSpacerItem(20,20, QtGui.QSizePolicy.Minimum, QtGui.QSizePolicy.Expanding)
         layout.addItem(self.spacer)
         
-        self.buttonBox = QtGui.QDialogButtonBox(QtGui.QDialogButtonBox.Ok | QtGui.QDialogButtonBox.Cancel)               
+        self.buttonBox = QtGui.QDialogButtonBox(QtGui.QDialogButtonBox.Ok | QtGui.QDialogButtonBox.Cancel)
+        self.okButton = self.buttonBox.button(QtGui.QDialogButtonBox.Ok)
         layout.addWidget(self.buttonBox)
         self.setLayout(layout)
 
         self.buttonBox.accepted.connect(self.okPressed)
         self.buttonBox.rejected.connect(self.cancelPressed)
-           
-    def getWorkspace(self):        
+
+        self.nameBox.nameValidityChanged.connect(self.updateOkButton)
+        self.uriBox.textChanged.connect(self.updateOkButton)
+        self.updateOkButton()
+
+    def getWorkspace(self):
         return self.workspace
-    
+
+    def updateOkButton(self):
+        ok = self.nameBox.isValid() and self.uriBox.text() != ''
+        self.okButton.setEnabled(ok)
     
     def okPressed(self):
         self.uri = unicode(self.uriBox.text())
-        self.name = unicode(self.nameBox.text()) 
+        self.name = unicode(self.nameBox.definedName())
         self.close()
 
     def cancelPressed(self):
         self.uri = None
         self.name = None
-        self.close()  
+        self.close()
+
+if __name__ == '__main__':
+    wsdlg = DefineWorkspaceDialog(workspaces=['ws_one', 'ws_two'])
+    wsdlg.exec_()

--- a/src/opengeo/gui/gsexploreritems.py
+++ b/src/opengeo/gui/gsexploreritems.py
@@ -483,7 +483,9 @@ class GsStylesItem(GsTreeItem):
         explorer.run(ogcat.cleanUnusedStyles, "Clean (remove unused styles)", [self])
 
     def createStyleFromLayer(self, explorer):
-        dlg = StyleFromLayerDialog()
+        catalog = self.parentCatalog()
+        styles = [style.name for style in catalog.get_styles()]
+        dlg = StyleFromLayerDialog(styles=styles)
         dlg.exec_()
         if dlg.layer is not None:
             ogcat = OGCatalog(self.catalog)
@@ -491,6 +493,7 @@ class GsStylesItem(GsTreeItem):
                      "Create style from layer '" + dlg.layer + "'",
                      [self],
                      dlg.layer, True, dlg.name)
+            explorer.refreshContent()
 
 
 class GsCatalogItem(GsTreeItem):

--- a/src/opengeo/gui/gsexploreritems.py
+++ b/src/opengeo/gui/gsexploreritems.py
@@ -426,7 +426,8 @@ class GsWorkspacesItem(GsTreeItem):
         return [createWorkspaceAction]
 
     def createWorkspace(self, explorer):
-        dlg = DefineWorkspaceDialog()
+        workspaces = [ws.name for ws in self.parentCatalog().get_workspaces()]
+        dlg = DefineWorkspaceDialog(workspaces=workspaces)
         dlg.exec_()
         if dlg.name is not None:
             explorer.run(self.parentCatalog().create_workspace,

--- a/src/opengeo/gui/gsexploreritems.py
+++ b/src/opengeo/gui/gsexploreritems.py
@@ -952,10 +952,10 @@ class GsLayerItem(GsTreeItem):
 
     def addStyleToLayer(self, explorer):
         cat = self.parentCatalog()
-        dlg = AddStyleToLayerDialog(cat)
+        layer = self.element
+        dlg = AddStyleToLayerDialog(cat, layer)
         dlg.exec_()
         if dlg.style is not None:
-            layer = self.element
             styles = layer.styles
             if dlg.default:
                 default = layer.default_style

--- a/src/opengeo/gui/gsnameutils.py
+++ b/src/opengeo/gui/gsnameutils.py
@@ -1,0 +1,209 @@
+"""
+Utilities to create a user-defined name for a GeoServer component, with optional
+validation.
+"""
+
+from PyQt4 import QtGui, QtCore
+
+APP = None
+if __name__ == '__main__':
+    import sys
+    # instantiate QApplication before importing QtGui subclasses
+    APP = QtGui.QApplication(sys.argv)
+
+from opengeo.gui.contextualhelp import InfoIcon
+
+
+# noinspection PyPep8Naming
+def xmlNameFixUp(name):
+    return name.lower().replace(' ', '_')
+
+
+# noinspection PyPep8Naming
+def xmlNameRegex():
+    # return r'^(?!XML)[a-z][\w0-9-\.]'
+    # return r'^(?!XML|\d|\W)\S+'
+    return r'^(?!XML|\d|\W)[a-z]\S*'
+
+
+# noinspection PyPep8Naming
+def xmlNameRegexMsg():
+    return (
+        'Text must be a valid XML name:\n\n'
+        '* Can contain letters, numbers, and other characters\n'
+        '* Cannot start with a number or punctuation character\n'
+        '* Cannot start with the letters \'xml\' (case-insensitive)\n'
+        '* Cannot contain spaces'
+    )
+
+
+# noinspection PyAttributeOutsideInit, PyPep8Naming
+class GSNameWidget(QtGui.QWidget):
+
+    nameValidityChanged = QtCore.pyqtSignal(bool)  # pragma: no cover
+    overwritingChanged = QtCore.pyqtSignal(bool)  # pragma: no cover
+
+    def __init__(self, name='', namemsg='', nameregex='', nameregexmsg='',
+                 names=None, unique=False,
+                 maxlength=0, parent=None):
+        super(GSNameWidget, self).__init__(parent)
+        self.name = name
+        self.namemsg = namemsg
+        self.nameregex = nameregex
+        self.nameregexmsg = nameregexmsg if nameregex else ''
+        self.names = names if names is not None else []
+        self.hasnames = len(self.names) > 0
+        self.unique = self.hasnames and unique
+        self.overwriting = False
+        self.maxlength = maxlength if maxlength >= 0 else 0  # no negatives
+        self.valid = True  # False will not trigger signal for setEnabled slots
+        self.initGui()
+        self.validateName()
+        
+    def initGui(self):
+        layout = QtGui.QHBoxLayout()
+        layout.setMargin(0)
+        layout.setSpacing(6)
+
+        self.nameBox = QtGui.QComboBox(self)
+        self.nameBox.setEditable(True)
+        if self.hasnames:
+            self.nameBox.addItems(self.names)
+        self.nameBox.setCurrentIndex(-1)
+
+        self.nameBox.lineEdit().setText(self.name)
+        self.nameBox.lineEdit().textChanged.connect(self.validateName)
+        self.nameValidityChanged.connect(self.highlightName)
+        layout.addWidget(self.nameBox)
+
+        tip = 'Define a{0}{1} name'.format(' valid' if self.nameregex else '',
+                                           ' unique' if self.unique else '')
+        if self.maxlength > 0:
+            tip += ' <= {0} characters'.format(self.maxlength)
+        if self.hasnames and not self.unique:
+            tip += ' or choose from existing'
+
+        if self.namemsg:
+            if tip:
+                tip += '\n\n'
+            tip += self.namemsg
+
+        if self.nameregexmsg:
+            if tip:
+                tip += '\n\n'
+            tip += self.nameregexmsg
+
+        if self.namemsg or self.nameregex or self.nameregexmsg or self.hasnames:
+            infolabel = InfoIcon(tip, self)
+            layout.addWidget(infolabel)
+
+        self.setLayout(layout)
+
+    def isValid(self):
+        return self.valid
+
+    def definedName(self):
+        return unicode(self.nameBox.lineEdit().text()) if self.valid else None
+
+    def overwritingName(self):
+        return self.overwriting
+
+    @QtCore.pyqtSlot(str)
+    def setName(self, txt):
+        self.nameBox.lineEdit().setText(txt)
+
+    @QtCore.pyqtSlot(list)
+    def setNames(self, names):
+        curname = self.nameBox.currentText()
+        self.names = names
+        self.nameBox.clear()
+        if len(names) > 0:
+            self.nameBox.addItems(names)
+        if curname != self.nameBox.currentText():
+            self.setName(curname)  # validates
+        else:
+            self.validateName()
+
+    @QtCore.pyqtSlot(str, str)
+    def setNameRegex(self, regex, regexmsg):
+        self.nameregex = regex
+        self.nameregexmsg = regexmsg
+        self.validateName()
+
+    @QtCore.pyqtSlot(int)
+    def setMaxLength(self, num):
+        self.maxlength = num
+        self.validateName()
+
+    @QtCore.pyqtSlot(bool)
+    def setUnique(self, unique):
+        self.unique = self.hasnames and unique
+        self.validateName()
+
+    @QtCore.pyqtSlot()
+    def validateName(self, name=None):
+        if name is None:
+            name = self.nameBox.lineEdit().text()
+        curvalid = self.valid
+        curoverwriting = self.overwriting
+
+        # no zero char names allowed
+        valid = len(name) > 0
+
+        # check if character limit reached
+        if valid and self.maxlength > 0:
+            valid = len(name) <= self.maxlength
+
+        # validate regex, if defined
+        if valid and self.nameregex:
+            rx = QtCore.QRegExp(self.nameregex, 0)
+            valid = rx.exactMatch(name)
+
+        overwriting = False
+        if valid:
+            if self.unique:  # crosscheck for unique name
+                valid = name not in self.names
+            else:  # crosscheck for overwrite
+                overwriting = name in self.names
+
+        if curoverwriting != overwriting:
+            self.overwriting = overwriting
+            self.overwritingChanged.emit(overwriting)
+
+        if curvalid != valid:
+            self.valid = valid
+            self.nameValidityChanged.emit(valid)
+
+    @QtCore.pyqtSlot()
+    def highlightName(self):
+        self.nameBox.lineEdit().setStyleSheet(
+            '' if self.valid else 'QLineEdit {color: rgb(200, 0, 0)}')
+
+
+if __name__ == '__main__':
+    # noinspection PyPep8Naming
+    class BounceObj(QtCore.QObject):
+
+        @QtCore.pyqtSlot(bool)
+        def valididtyChanged(self, valid):
+            print "valididty changed: {0}".format(valid)
+
+        @QtCore.pyqtSlot(bool)
+        def overwritingChanged(self, overwrite):
+            print "overwriting changed: {0}".format(overwrite)
+
+    bobj = BounceObj()
+    gdlg = GSNameWidget(
+        namemsg='Sample is generated from PostgreSQL connection name',
+        name=xmlNameFixUp('My PG connection'),
+        nameregex=xmlNameRegex(),
+        nameregexmsg=xmlNameRegexMsg(),
+        names=['name_one', 'name_two'],
+        unique=False,
+        maxlength=10)
+    gdlg.nameValidityChanged.connect(bobj.valididtyChanged)
+    gdlg.overwritingChanged.connect(bobj.overwritingChanged)
+    gdlg.show()
+    gdlg.raise_()
+    gdlg.activateWindow()
+    sys.exit(APP.exec_())

--- a/src/opengeo/gui/qgsexploreritems.py
+++ b/src/opengeo/gui/qgsexploreritems.py
@@ -373,7 +373,7 @@ class QgsStyleItem(QgsTreeItem):
         return [publishStyleAction, editAction]
 
     def publishStyle(self, tree, explorer):
-        dlg = PublishStyleDialog(explorer.catalogs().keys())
+        dlg = PublishStyleDialog(explorer.catalogs(), self.element.name())
         dlg.exec_()
         if dlg.catalog is None:
             return

--- a/src/opengeo/test/coveragerc
+++ b/src/opengeo/test/coveragerc
@@ -2,7 +2,6 @@
 [report]
 exclude_lines =
   pragma: no cover
-  @.*pyqtSlot()
   if __name__ == '__main__':
   if __name__ == "__main__":
 ignore_errors = True

--- a/src/opengeo/test/guitests.py
+++ b/src/opengeo/test/guitests.py
@@ -107,20 +107,16 @@ class GroupDialogTests(ExplorerIntegrationTest):
                                         
     def testGroupDialogWithEmptyName(self):
         dialog = LayerGroupDialog(self.cat)
-        dialog.nameBox.setText("")
+        dialog.nameBox.setName("")
         okWidget = dialog.buttonBox.button(dialog.buttonBox.Ok)
-        QTest.mouseClick(okWidget, Qt.LeftButton)
-        self.assertIsNone(dialog.group)
-        self.assertEquals("QLineEdit{background: yellow}", dialog.nameBox.styleSheet())
-        
+        self.assertFalse(okWidget.isEnabled())
+
     def testGroupDialogWithNameContaingBlankSpaces(self):
         dialog = LayerGroupDialog(self.cat)
-        dialog.nameBox.setText("my group")
+        dialog.nameBox.setName("my group")
         dialog.table.cellWidget(0, 0).setChecked(True)
         okWidget = dialog.buttonBox.button(dialog.buttonBox.Ok)
-        QTest.mouseClick(okWidget, Qt.LeftButton)
-        self.assertIsNotNone(dialog.group)
-        self.assertEquals("my_group", dialog.group.name)
+        self.assertFalse(okWidget.isEnabled())
     
     def testSelectAllButton(self):
         dialog = LayerGroupDialog(self.cat)        
@@ -444,7 +440,7 @@ class GSNameDialogTest(unittest.TestCase):
         self.assertTrue(ndlg.overwritingName())
 
 
-class InfoIconTets(unittest.TestCase):
+class InfoIconTest(unittest.TestCase):
 
     def testInfoIcon(self):
         iw = QWidget()


### PR DESCRIPTION
This is a start to fixing up XML names for GeoServer components. Initial support includes:

* New workspace (also limited to 10 characters)
* New/existing layer group
* New/QGIS layer style

Currently, no support for adding QGIS or PostGIS layers or drag/drop operations, see below.

The new widgets to handle XML validation:

* `GSNameWidget` - has name validation, contextual help, selection from existing names; outputs the defined name and whether the name choice is an overwrite of an existing name or should be unique
* `GSNameDialog` - simple dialog wrapper for name widget
* `InfoIcon` - simple help icon that shows a tool tip on hover

The shift in UX revolves around the `GSNameWidget` handling the user interaction of whether to overwrite an existing name. This means such existing names need to be gathered and passed to the widget/dialog. Then, the user is notified when choosing a name if it will be an overwrite, unless it has to be unique. Essentially, any dialog that now notifies the user that a name already existing can be replaced with an interactive dialog for choosing to overwrite or creating a new name.

For QGIS/PostGIS layers or drag/drop operations, there needs to be some more significant changes, as there appears to be a static naming relation between datastore/layer/style upon creation to be resolved. The user needs to be able to have individual control over *all* of the naming to avoid naming errors and any conflicts with existing component names. This means no naming should be automated, though sensible defaults for the name widget will make things quicker, even for delegated cells within a table widget.

If this UX approach is reasonable, I will continue with its integration.