### PR TITLE
Fix for "error publishing edits back to GeoServer" issue

### DIFF
--- a/src/opengeo/qgis/uri.py
+++ b/src/opengeo/qgis/uri.py
@@ -24,15 +24,15 @@ def layerUri(layer):
             else:
                 _params['authid'] = catalog.authid
         else:
-            _params['password'] = catalog.password
-            _params['username'] = catalog.username
+            _params['PASSWORD'] = catalog.password
+            _params['USERNAME'] = catalog.username
     if resource.resource_type == 'featureType':
         params = {
-            'service': 'WFS',
-            'version': '1.0.0',
-            'request': 'GetFeature',
-            'typename': resource.workspace.name + ":" + layer.name,
-            'srsname': resource.projection,
+            'SERVICE': 'WFS',
+            'VERSION': '1.0.0',
+            'REQUEST': 'GetFeature',
+            'TYPENAME': resource.workspace.name + ":" + layer.name,
+            'SRSNAME': resource.projection,
         }
         addAuth(params)
         uri = layer.catalog.gs_base_url + 'wfs?' + urllib.unquote(urllib.urlencode(params))


### PR DESCRIPTION
I think I found what causes #136. It turns out that QGIS sends a `POST` `GetFeature` request when publishing edits on a layer that's been loaded through the plugin. See this mitmproxy screenshot below (request is at the top).

![screenshot 2015-11-19 20 13 44](https://cloud.githubusercontent.com/assets/778666/11281979/5250392e-8efd-11e5-90e3-a12825acbc8b.png)

This is of course very weird. Comparing it to the request that QGIS' "native" WFS sends I noticed that the latter capitalizes the query parameters whereas the former doesn't.

After capitalizing the parameters in `uri.py` QGIS sends a correct `POST` request and the transaction succeeds, see below.

![screenshot 2015-11-19 20 22 32](https://cloud.githubusercontent.com/assets/778666/11282056/a74aceda-8efd-11e5-9392-51bbba5210a4.png)

I tested this on four machines (2 x Win, 2 x OS X) and different QGIS verions and it worked on all of them.
